### PR TITLE
Ticket7405

### DIFF
--- a/system_tests/lewis_emulators/Tjmper/interfaces/stream_interface.py
+++ b/system_tests/lewis_emulators/Tjmper/interfaces/stream_interface.py
@@ -30,7 +30,7 @@ class TjmperStreamInterface(StreamInterface):
 
     @conditional_reply("connected")
     def get_status(self):
-        return "ACK\rITJ{},OPM{},LMT{}{}{}{}{}{},AIR{},ERR{}".format(
+        return "TJA{},OPM{},LMT{}{}{}{}{}{},AIR{},ERR{}".format(
             self.device.id,
             self.device.operating_mode,
             self.device.plate_1_home, self.device.plate_1_engaged,

--- a/tjmperSup/tjmper.proto
+++ b/tjmperSup/tjmper.proto
@@ -1,10 +1,11 @@
 Terminator = CR;
-ReplyTimeout = 1000;
+ReplyTimeout = 2000;
+ReadTimeout = 2000;
+LockTimeout = 10000;
 
 getStatus {
     out "?STS";
-    in "ACK";
-    in "ITJ%d,OPM%(\$1MODE)d,LMT%(\$1LMT)b,AIR%(\$1AIR)d,ERR%(\$1ERR)d";
+    in "TJA%d,OPM%(\$1MODE)d,LMT%(\$1LMT)b,AIR%(\$1AIR)d,ERR%(\$1ERR)d";
 }
 
 setMode {


### PR DESCRIPTION
When testing the device, discovered that some longer timeouts were needed for the `status` command to be read correctly. Also fixed the command string.

https://github.com/ISISComputingGroup/IBEX/issues/7405